### PR TITLE
Remove all direct links to languagetransfer.org

### DIFF
--- a/js/components/About/About.react.tsx
+++ b/js/components/About/About.react.tsx
@@ -64,14 +64,7 @@ const About = () => {
             will take care of itself!
           </Text>
 
-          {donationLinksNotAllowedBecauseGooglePlayIsAStinkyPooPoo ? (
-            <>
-              <Text style={[styles.bodyText, styles.bodyTextAboveButton]}>
-                Language Transfer is a unique project in more ways than one.
-                Learn more about Language Transfer here:
-              </Text>
-            </>
-          ) : (
+          {donationLinksNotAllowedBecauseGooglePlayIsAStinkyPooPoo ? null : (
             <>
               <Text style={styles.bodyText}>
                 Language Transfer is totally free, developed by Mihalis
@@ -131,25 +124,6 @@ const About = () => {
               </View>
             </>
           )}
-
-          <View style={styles.additionalButton}>
-            <TouchableNativeFeedback
-              onPress={() => {
-                log({
-                  action: 'visit_website',
-                  surface: 'about',
-                });
-                Linking.openURL('https://www.languagetransfer.org/about');
-              }}
-              useForeground={true}>
-              <View style={styles.additionalButtonInner}>
-                <Text style={styles.additionalButtonText}>
-                  Visit languagetransfer.org
-                </Text>
-                <Icon name="link" type="font-awesome-5" />
-              </View>
-            </TouchableNativeFeedback>
-          </View>
 
           <View style={styles.additionalButton}>
             <TouchableNativeFeedback

--- a/js/components/LanguageHome/LanguageHome.react.tsx
+++ b/js/components/LanguageHome/LanguageHome.react.tsx
@@ -108,26 +108,7 @@ const LanguageHomeBody = ({route}: {route: any}) => {
           </TouchableNativeFeedback>
         </View>
 
-        {donationLinksNotAllowedBecauseGooglePlayIsAStinkyPooPoo ? (
-          <View style={styles.additionalButton}>
-            <TouchableNativeFeedback
-              onPress={() => {
-                log({
-                  action: 'visit_website',
-                  surface: 'language_home',
-                });
-                Linking.openURL('https://www.languagetransfer.org/');
-              }}
-              useForeground={true}>
-              <View style={styles.additionalButtonInner}>
-                <Text style={styles.additionalButtonText}>
-                  Visit languagetransfer.org
-                </Text>
-                <Icon name="link" type="font-awesome-5" />
-              </View>
-            </TouchableNativeFeedback>
-          </View>
-        ) : (
+        {donationLinksNotAllowedBecauseGooglePlayIsAStinkyPooPoo ? null : (
           <View style={styles.additionalButton}>
             <TouchableNativeFeedback
               onPress={() => {


### PR DESCRIPTION
When we first published to the Google Play Store, the app was rejected because we had a link to Language Transfer's Patreon:

![image](https://user-images.githubusercontent.com/1474671/129395596-599879df-a888-4ca5-aa9a-1b27166879d9.png)

Since this was a way of soliciting funds (for our _free, open-source project_) that didn't give Google a 30% cut, it wasn't allowed. This sucked, because Language Transfer is run entirely on donations (which pay Mihalis's rent), and now our main distribution mechanism (the mobile app) wasn't even allowed to fundraise. The app doesn't provide any special features to people who donate; it's just a way to help support the project. Google makes an exception for tax-exempt nonprofits, but Language Transfer is a small project run by one guy. If we want to let people donate, Google wants a cut.

To appease Google, we swapped out those links for links to the [Language Transfer website](https://www.languagetransfer.org/) so that users could learn more about the project themselves. Google accepted this version of the app to the Play Store, and (about a year later) it's now on around 50,000 devices.

Today, Google pulled the app from the Play Store (with no notice, as is their way) with this series of screenshots attached to the rejection:

![image](https://user-images.githubusercontent.com/1474671/129396299-a0028470-5543-4cc0-8d22-0f0ca975a14e.png)
![org languagetransfer-InAppExperience-410](https://user-images.githubusercontent.com/1474671/129396236-489e6336-e6ac-4a64-85c1-bbb85d48350d.png)

That's right; someone at Google reviewed this app, visited the LT website, scrolled to the very bottom of the page, and clicked through twice to find a way to contribute funds to the project. Our app isn't allowed to link to the homepage of the project's own website unless we completely remove our users' ability to discover a way to give us money.

I'm hoping this PR is enough, but we're still linking the GitHub page (which seems, yknow, reasonable, for an open-source app) and the Facebook page (again, doesn't everyone do this?), and of course it will be possible to find ways to donate through either of those links. We'll just have to hope that this is good enough for Google.