### PR TITLE
Add a soft rating prompt

### DIFF
--- a/js/components/LanguageHome/LanguageHomeTopButton.react.tsx
+++ b/js/components/LanguageHome/LanguageHomeTopButton.react.tsx
@@ -1,12 +1,14 @@
 import React, {useState, useCallback} from 'react';
-import {StyleSheet, View, Text} from 'react-native';
+import {StyleSheet, View, Text, Linking, Platform} from 'react-native';
 import {useFocusEffect, useNavigation} from '@react-navigation/native';
 
 import {Icon} from 'react-native-elements';
 import {TouchableNativeFeedback} from 'react-native-gesture-handler';
 import {
   genMostRecentListenedLessonForCourse,
+  genPreferenceRatingButtonDismissed,
   genProgressForLesson,
+  genSetPreferenceRatingButtonDismissed,
   Progress,
 } from '../../persistence';
 
@@ -14,6 +16,7 @@ import CourseData from '../../course-data';
 
 import formatDuration from 'format-duration';
 import { MainNavigationProp } from '../App.react';
+import { log } from '../../metrics';
 
 const getNextLesson = (
   course: Course,
@@ -35,13 +38,58 @@ const getNextLesson = (
   return nextLesson;
 };
 
+const renderRatingBanner = (currentLesson: number, ratingButtonDismissed: boolean, dismissRatingButton: (explicit: boolean) => void) => {
+  if (Platform.OS !== 'android') {
+    return null; // for now
+  }
+
+  if (currentLesson + 1 < 10 || ratingButtonDismissed) {
+    return null;
+  }
+
+  return (
+    <View style={styles.ratingBanner}>
+      <Text style={styles.ratingPrompt}>Help people find Language Transfer!</Text>
+      <View style={styles.ratingButtonContainer}>
+        <TouchableNativeFeedback style={styles.ratingButton} onPress={() => {
+          log({
+            action: 'open_google_play',
+            surface: 'rate_button',
+          });
+          dismissRatingButton(false);
+          Linking.openURL('http://play.google.com/store/apps/details?id=org.languagetransfer');
+        }}>
+          <View style={styles.ratingButtonInner}>
+            <Icon color="white" name="star" solid size={14} type="font-awesome-5" />
+            <Text style={styles.ratingButtonText}>Rate</Text>
+          </View>
+        </TouchableNativeFeedback>
+      </View>
+      <View style={styles.dismissRatingBannerButtonContainer}>
+        <TouchableNativeFeedback style={styles.dismissRatingBannerButton} onPress={() => {
+          log({
+            action: 'dismiss_rating_button',
+            surface: 'rate_button',
+          });
+          dismissRatingButton(true);
+        }}>
+          <View style={styles.dismissRatingBannerButtonInner}>
+            <Icon color="white" name="times" size={14} type="font-awesome-5" />
+          </View>
+        </TouchableNativeFeedback>
+      </View>
+    </View>
+  );
+};
+
 const LanguageHomeTopButton = ({course}: {course: Course}) => {
   const {navigate} = useNavigation<MainNavigationProp<'Language Home'>>();
   const [lastListenState, setLastListenState] = useState<any>(null);
+  const [dismissedRateButton, setDismissedRateButton] = useState<boolean | null>(null);
 
   useFocusEffect(
     useCallback(() => {
-      const update = async () => {
+      const updateProgress = async () => {
         const lesson = await genMostRecentListenedLessonForCourse(course);
         const progress = await genProgressForLesson(course, lesson);
 
@@ -56,13 +104,19 @@ const LanguageHomeTopButton = ({course}: {course: Course}) => {
         });
       };
 
-      update();
+      const updateRatingButtonDismissed = async () => {
+        const { dismissed } = await genPreferenceRatingButtonDismissed();
+        setDismissedRateButton(dismissed);
+      };
+
+      updateProgress();
+      updateRatingButtonDismissed();
     }, [course]),
   );
 
   // TODO: kinda temp, but at least it doesn't look awful. should add a loading thingy.
   // just make sure it's the same height as the actual button
-  if (lastListenState === null) {
+  if (lastListenState === null || dismissedRateButton === null) {
     return <View style={[styles.lessonPlayBox, styles.invisible]}>
       <View style={styles.lessonPlayBoxInner}>
         <View style={styles.textPlayFlex}>
@@ -124,6 +178,15 @@ const LanguageHomeTopButton = ({course}: {course: Course}) => {
           </View>
         </View>
       </TouchableNativeFeedback>
+      {renderRatingBanner(lesson, dismissedRateButton, async (explicit: boolean) => {
+        await genSetPreferenceRatingButtonDismissed(JSON.stringify({
+          dismissed: true,
+          surface: 'LanguageHomeTopButton',
+          explicit,
+          time: +new Date(),
+        }));
+        setDismissedRateButton(true);
+      })}
     </View>
   );
 };
@@ -168,6 +231,44 @@ const styles = StyleSheet.create({
   progressText: {
     flexDirection: 'row',
     justifyContent: 'space-between',
+  },
+  ratingBanner: {
+    backgroundColor: '#0289ee',
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  ratingPrompt: {
+    color: 'white',
+    fontSize: 14,
+    paddingLeft: 12,
+    flex: 8,
+  },
+  ratingButtonContainer: {
+    flex: 2,
+  },
+  ratingButton: {
+    paddingVertical: 12,
+    minWidth: 36,
+  },
+  ratingButtonInner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  ratingButtonText: {
+    color: 'white',
+    marginLeft: 4,
+  },
+  dismissRatingBannerButtonContainer: {
+    flex: 1,
+    minWidth: 10,
+  },
+  dismissRatingBannerButton: {
+    paddingVertical: 12,
+  },
+  dismissRatingBannerButtonInner: {
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });
 

--- a/js/components/LanguageHome/LanguageHomeTopButton.react.tsx
+++ b/js/components/LanguageHome/LanguageHomeTopButton.react.tsx
@@ -57,7 +57,7 @@ const renderRatingBanner = (currentLesson: number, ratingButtonDismissed: boolea
             surface: 'rate_button',
           });
           dismissRatingButton(false);
-          Linking.openURL('http://play.google.com/store/apps/details?id=org.languagetransfer');
+          Linking.openURL('https://play.google.com/store/apps/details?id=org.languagetransfer');
         }}>
           <View style={styles.ratingButtonInner}>
             <Icon color="white" name="star" solid size={14} type="font-awesome-5" />

--- a/js/components/LanguageSelector/LanguageSelector.react.tsx
+++ b/js/components/LanguageSelector/LanguageSelector.react.tsx
@@ -7,7 +7,6 @@ import {
   Animated,
   TouchableNativeFeedback,
   Text,
-  Platform,
 } from 'react-native';
 import useStatusBarStyle from '../../hooks/useStatusBarStyle';
 import LanguageButton from './LanguageButton.react';

--- a/js/components/Navigation/DrawerContent.react.tsx
+++ b/js/components/Navigation/DrawerContent.react.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import {StyleSheet, Text, View, Image} from 'react-native';
 import {DrawerContentScrollView, DrawerItem} from '@react-navigation/drawer';
-import {Icon} from 'react-native-elements';import {navigate} from '../../navigation-ref';
+import {Icon} from 'react-native-elements';
+import {navigate} from '../../navigation-ref';
 
 
 const Drawer = (props: any) => {

--- a/js/persistence.ts
+++ b/js/persistence.ts
@@ -210,6 +210,11 @@ export const [
   genSetPreferenceIsFirstLoad,
 ] = preference('is-first-load', true, (b) => b === 'true');
 
+export const [
+  genPreferenceRatingButtonDismissed,
+  genSetPreferenceRatingButtonDismissed,
+] = preference('rating-button-dismissed', { dismissed: false }, (o) => JSON.parse(o));
+
 export function usePreference<T>(key: Preference, defaultValue: any) {
   const [value, setValue] = useState<T>(null!);
 

--- a/typings/interfaces.d.ts
+++ b/typings/interfaces.d.ts
@@ -19,7 +19,8 @@ declare global {
     | 'download-quality'
     | 'download-only-on-wifi'
     | 'allow-data-collection'
-    | 'is-first-load';
+    | 'is-first-load'
+    | 'rating-button-dismissed';
 
   type Quality = 'high' | 'low';
 


### PR DESCRIPTION
Once you hit lesson 10, this will show a banner asking you to rate the app:

![image](https://user-images.githubusercontent.com/1474671/133198471-ab60c5b5-f99a-4f34-8a40-ada28664e774.png)

Either button (the "Rate" button or the "X" button) will dismiss the banner permanently. We've found that users do love Language Transfer and actually do rate it pretty often; on Google Play we have ~1400 ratings and about ~64k active devices, which seems like a good ratio. The idea here is just to give a quick nudge to users who have been using the app for a while and give them a frictionless way to get into the rating flow. No need to nag, though; if they don't feel like rating, we won't ask again (at least for now -- I'm saving a little metadata so we can maybe find a less extreme solution in the future that's still not annoying).