### PR TITLE
Fix iOS bundle track download bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ import DownloadManager from './js/download-manager';
 
 AppRegistry.registerComponent(appName, () => App);
 TrackPlayer.registerPlaybackService(() => audioService);
-DownloadManager.copyBundledTracksOnLoad();
+DownloadManager.copyBundledTracksIfNotPresent();
 DownloadManager.resumeDownloads();
 
 console.disableYellowBox = true; // not my fault, I swear, the track player library is the culprit

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ import DownloadManager from './js/download-manager';
 
 AppRegistry.registerComponent(appName, () => App);
 TrackPlayer.registerPlaybackService(() => audioService);
-DownloadManager.copyBundledTracksIfFirstLoad();
+DownloadManager.copyBundledTracksOnLoad();
 DownloadManager.resumeDownloads();
 
 console.disableYellowBox = true; // not my fault, I swear, the track player library is the culprit

--- a/js/download-manager.ts
+++ b/js/download-manager.ts
@@ -245,7 +245,7 @@ const DownloadManager = {
     });
   },
 
-  copyBundledTracksOnLoad: async (): Promise<void> => {
+  copyBundledTracksIfNotPresent: async (): Promise<void> => {
     // this code runs every time on startup and copies the bundled tracks in iOS
     // into the course downloads.
     // this is so rntp can load bundled tracks from the local filesystem like other tracks

--- a/js/download-manager.ts
+++ b/js/download-manager.ts
@@ -245,26 +245,31 @@ const DownloadManager = {
     });
   },
 
-  copyBundledTracksIfFirstLoad: async (): Promise<void> => {
-    if (await genPreferenceIsFirstLoad()) {
-      for (const course of CourseData.getCourseList()) {
-        if (CourseData.getBundledFirstLesson(course) === null) continue;
+  copyBundledTracksOnLoad: async (): Promise<void> => {
+    // this code runs every time on startup and copies the bundled tracks in iOS
+    // into the course downloads.
+    // this is so rntp can load bundled tracks from the local filesystem like other tracks
+    // instead of having to load them from within the app bundle
+    for (const course of CourseData.getCourseList()) {
+      // first, check to see if the lesson is bundled
+      // this will always return false on Android since courses are not bundled
+      if (CourseData.getBundledFirstLesson(course) === null) continue;
+      // if it is, check to see if it's already downloaded
+      if (await DownloadManager.genIsDownloadedForDownloadId(CourseData.getBundledFirstLessonId(course))) continue;
 
-        const localUrl = Image.resolveAssetSource(CourseData.getBundledFirstLesson(course)).uri;
-        DownloadManager.attachCallbacks(Downloader.download({
-          id: CourseData.getBundledFirstLessonId(course),
-          url: localUrl,
-          destination: DownloadManager.getDownloadStagingLocation(
-            CourseData.getBundledFirstLessonId(course),
-          ),
-          // @ts-ignore
-          network: Downloader.Network.ALL,
-        }));
-      }
+      // if the course isn't downloaded yet, download it
+      const localUrl = Image.resolveAssetSource(CourseData.getBundledFirstLesson(course)).uri;
+      DownloadManager.attachCallbacks(Downloader.download({
+        id: CourseData.getBundledFirstLessonId(course),
+        url: localUrl,
+        destination: DownloadManager.getDownloadStagingLocation(
+          CourseData.getBundledFirstLessonId(course),
+        ),
+        // @ts-ignore
+        network: Downloader.Network.ALL,
+      }));
     }
-
-    await genSetPreferenceIsFirstLoad(false);
-  },
+  }
 };
 
 export const useDownloadStatus = (


### PR DESCRIPTION
Tested on Android and iOS, Android bails out of it every time and iOS appears to mark every track as downloaded as intended.